### PR TITLE
Add global.json

### DIFF
--- a/MiniTwitch.sln
+++ b/MiniTwitch.sln
@@ -13,6 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		LICENSE = LICENSE
+		global.json = global.json
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{C1BCE870-D158-438A-91C6-387B2F7677B4}"

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+	"sdk": {
+		"version": "6.0.0",
+		"rollForward": "latestMinor",
+		"allowPrerelease": true
+	}
+}


### PR DESCRIPTION
As described in #2, a `global.json` file will make it clear for unsupported SDKs that they shouldn't be loading/building this solution.

This PR adds a `global.json` file with the roll format of 'latestMinor' and also allows pre-release versions