### PR TITLE
Add an option to apply message ratelimits globally

### DIFF
--- a/MiniTwitch.Irc.Test/RateLimitManagerTests.cs
+++ b/MiniTwitch.Irc.Test/RateLimitManagerTests.cs
@@ -8,13 +8,14 @@ public class RateLimitManagerTests
     [Fact]
     public async Task Spam_RateLimited()
     {
-        RateLimitManager manager = new(new() { MessageRateLimit = 30 }) { MessagePeriod = 5000 };
+        RateLimitManager manager = new(new() { MessageRateLimit = 30, UseGlobalRateLimit = false }) { MessagePeriod = 5000 };
         for (int i = 0; i < 30; i++)
         {
             Assert.True(manager.CanSend("foo", false));
         }
 
         Assert.False(manager.CanSend("foo", false));
+        Assert.True(manager.CanSend("foo2", false));
         await Task.Delay(manager.MessagePeriod + 100);
         Assert.True(manager.CanSend("foo", false));
     }
@@ -22,13 +23,14 @@ public class RateLimitManagerTests
     [Fact]
     public void ModSpam_RateLimited()
     {
-        RateLimitManager manager = new(new() { ModMessageRateLimit = 100 }) { MessagePeriod = 5000 };
+        RateLimitManager manager = new(new() { ModMessageRateLimit = 100, UseGlobalRateLimit = false }) { MessagePeriod = 5000 };
         for (int i = 0; i < 100; i++)
         {
             Assert.True(manager.CanSend("bar", true));
         }
 
         Assert.False(manager.CanSend("bar", true));
+        Assert.True(manager.CanSend("foo2", true));
         Thread.Sleep(manager.MessagePeriod + 100);
         Assert.True(manager.CanSend("bar", true));
     }

--- a/MiniTwitch.Irc.Test/RateLimitManagerTests.cs
+++ b/MiniTwitch.Irc.Test/RateLimitManagerTests.cs
@@ -1,0 +1,115 @@
+﻿using MiniTwitch.Irc.Internal;
+using Xunit;
+
+namespace MiniTwitch.Irc.Test;
+
+public class RateLimitManagerTests
+{
+    [Fact]
+    public async Task Spam_RateLimited()
+    {
+        RateLimitManager manager = new(new() { MessageRateLimit = 30 }) { MessagePeriod = 5000 };
+        for (int i = 0; i < 30; i++)
+        {
+            Assert.True(manager.CanSend("foo", false));
+        }
+
+        Assert.False(manager.CanSend("foo", false));
+        await Task.Delay(manager.MessagePeriod + 100);
+        Assert.True(manager.CanSend("foo", false));
+    }
+
+    [Fact]
+    public void ModSpam_RateLimited()
+    {
+        RateLimitManager manager = new(new() { ModMessageRateLimit = 100 }) { MessagePeriod = 5000 };
+        for (int i = 0; i < 100; i++)
+        {
+            Assert.True(manager.CanSend("bar", true));
+        }
+
+        Assert.False(manager.CanSend("bar", true));
+        Thread.Sleep(manager.MessagePeriod + 100);
+        Assert.True(manager.CanSend("bar", true));
+    }
+
+    [Fact]
+    public void Join_RateLimited()
+    {
+        RateLimitManager manager = new(new() { JoinRateLimit = 12 }) { JoinPeriod = 1000 };
+        for (int i = 0; i < 12; i++)
+        {
+            Assert.True(manager.CanJoin());
+        }
+
+        Assert.False(manager.CanJoin());
+        Thread.Sleep(manager.JoinPeriod + 100);
+        Assert.True(manager.CanJoin());
+    }
+
+    [Fact]
+    public async Task Global_Spam_RateLimited()
+    {
+        RateLimitManager manager = new(new() { MessageRateLimit = 30, UseGlobalRateLimit = true }) { MessagePeriod = 5000 };
+        for (int i = 0; i < 30; i++)
+        {
+            Assert.True(manager.CanSend($"foo{i}", false));
+        }
+
+        Assert.False(manager.CanSend("foo", false));
+        await Task.Delay(manager.MessagePeriod + 100);
+        Assert.True(manager.CanSend("foo", false));
+    }
+
+    [Fact]
+    public async Task Global_ModSpam_RateLimited()
+    {
+        RateLimitManager manager = new(new() { ModMessageRateLimit = 100, UseGlobalRateLimit = true }) { MessagePeriod = 5000 };
+        for (int i = 0; i < 100; i++)
+        {
+            Assert.True(manager.CanSend($"foo{i}", true));
+        }
+
+        Assert.False(manager.CanSend("foo", true));
+        await Task.Delay(manager.MessagePeriod + 100);
+        Assert.True(manager.CanSend("foo", true));
+    }
+
+    [Fact]
+    public async Task Global_SpamTransition_RateLimited()
+    {
+        RateLimitManager manager = new(new() { MessageRateLimit = 30, ModMessageRateLimit = 100, UseGlobalRateLimit = true }) { MessagePeriod = 5000 };
+        // mod to normal
+        for (int i = 0; i < 20; i++)
+        {
+            Assert.True(manager.CanSend($"foo{i}", true));
+        }
+        for (int i = 0; i < 10; i++)
+        {
+            Assert.True(manager.CanSend($"{i}oof", false));
+        }
+
+        Assert.False(manager.CanSend("fo123oooo", false));
+        Assert.True(manager.CanSend("fo123oooo", true));
+        await Task.Delay(manager.MessagePeriod + 100);
+        Assert.True(manager.CanSend("foo", true));
+        Assert.True(manager.CanSend("foo", false));
+
+        manager = new(new() { MessageRateLimit = 30, ModMessageRateLimit = 100, UseGlobalRateLimit = true }) { MessagePeriod = 5000 };
+        // normal to mod
+        for (int i = 0; i < 29; i++)
+        {
+            Assert.True(manager.CanSend($"foo{i}", false));
+        }
+        for (int i = 0; i < 70; i++)
+        {
+            Assert.True(manager.CanSend($"{i}oof", true));
+        }
+
+        Assert.True(manager.CanSend("fo123oooo", true));
+        Assert.False(manager.CanSend("fo123oooo", false));
+        await Task.Delay(manager.MessagePeriod + 100);
+        Assert.True(manager.CanSend("foo", true));
+        Assert.True(manager.CanSend("foo", false));
+    }
+}

--- a/MiniTwitch.Irc.Test/RateLimitManagerTests.cs
+++ b/MiniTwitch.Irc.Test/RateLimitManagerTests.cs
@@ -50,7 +50,7 @@ public class RateLimitManagerTests
     [Fact]
     public async Task Global_Spam_RateLimited()
     {
-        RateLimitManager manager = new(new() { MessageRateLimit = 30, UseGlobalRateLimit = true }) { MessagePeriod = 5000 };
+        RateLimitManager manager = new(new() { MessageRateLimit = 30 }) { MessagePeriod = 5000 };
         for (int i = 0; i < 30; i++)
         {
             Assert.True(manager.CanSend($"foo{i}", false));
@@ -64,7 +64,7 @@ public class RateLimitManagerTests
     [Fact]
     public async Task Global_ModSpam_RateLimited()
     {
-        RateLimitManager manager = new(new() { ModMessageRateLimit = 100, UseGlobalRateLimit = true }) { MessagePeriod = 5000 };
+        RateLimitManager manager = new(new() { ModMessageRateLimit = 100 }) { MessagePeriod = 5000 };
         for (int i = 0; i < 100; i++)
         {
             Assert.True(manager.CanSend($"foo{i}", true));
@@ -78,7 +78,7 @@ public class RateLimitManagerTests
     [Fact]
     public async Task Global_SpamTransition_RateLimited()
     {
-        RateLimitManager manager = new(new() { MessageRateLimit = 30, ModMessageRateLimit = 100, UseGlobalRateLimit = true }) { MessagePeriod = 5000 };
+        RateLimitManager manager = new(new() { MessageRateLimit = 30, ModMessageRateLimit = 100 }) { MessagePeriod = 5000 };
         // mod to normal
         for (int i = 0; i < 20; i++)
         {
@@ -95,7 +95,7 @@ public class RateLimitManagerTests
         Assert.True(manager.CanSend("foo", true));
         Assert.True(manager.CanSend("foo", false));
 
-        manager = new(new() { MessageRateLimit = 30, ModMessageRateLimit = 100, UseGlobalRateLimit = true }) { MessagePeriod = 5000 };
+        manager = new(new() { MessageRateLimit = 30, ModMessageRateLimit = 100 }) { MessagePeriod = 5000 };
         // normal to mod
         for (int i = 0; i < 29; i++)
         {

--- a/MiniTwitch.Irc/Internal/RateLimitManager.cs
+++ b/MiniTwitch.Irc/Internal/RateLimitManager.cs
@@ -41,7 +41,7 @@ internal sealed class RateLimitManager
             return true;
         }
 
-        int sent = _messages[channel].Count(x => time - x < MessagePeriod);
+        int sent = _messages[channel].Count(x => time - x < this.MessagePeriod);
         int old = _messages[channel].Count - sent;
 
         for (int i = 0; i < old; i++)
@@ -91,7 +91,7 @@ internal sealed class RateLimitManager
         }
 
         long time = DateTimeOffset.Now.ToUnixTimeMilliseconds();
-        int attempts = _joins.Count(x => time - x < JoinPeriod);
+        int attempts = _joins.Count(x => time - x < this.JoinPeriod);
         int old = _joins.Count - attempts;
 
         for (int i = 0; i < old; i++)
@@ -112,5 +112,5 @@ internal sealed class RateLimitManager
 
     private void RegisterJoin() => _joins.Enqueue(DateTimeOffset.Now.ToUnixTimeMilliseconds());
 
-    private int CalcGlobalMessages(long time) => _messages.SelectMany(x => x.Value).Count(x => time - x < MessagePeriod);
+    private int CalcGlobalMessages(long time) => _messages.SelectMany(x => x.Value).Count(x => time - x < this.MessagePeriod);
 }

--- a/MiniTwitch.Irc/Internal/RateLimitManager.cs
+++ b/MiniTwitch.Irc/Internal/RateLimitManager.cs
@@ -6,28 +6,39 @@ internal sealed class RateLimitManager
 {
     private readonly Dictionary<string, Queue<long>> _messages = new();
     private readonly Queue<long> _joins = new();
-    private readonly int _joinC;
-    private readonly int _normalC;
-    private readonly int _modC;
+    private readonly int _joinLimit;
+    private readonly int _normalLimit;
+    private readonly int _modLimit;
+    private readonly bool _isGlobal;
 
     public RateLimitManager(ClientOptions options)
     {
-        _joinC = options.JoinRateLimit;
-        _normalC = options.MessageRateLimit;
-        _modC = options.ModMessageRateLimit;
+        _joinLimit = options.JoinRateLimit;
+        _normalLimit = options.MessageRateLimit;
+        _modLimit = options.ModMessageRateLimit;
+        _isGlobal = options.UseGlobalRateLimit;
     }
 
     public bool CanSend(string channel, bool mod)
     {
+        long time = DateTimeOffset.Now.ToUnixTimeMilliseconds();
         if (!_messages.ContainsKey(channel))
         {
             _messages.Add(channel, new());
+            if (_isGlobal)
+            {
+                int gMessages = CalcGlobalMessages(time);
+                if (gMessages >= _modLimit)
+                    return false;
+                else if (gMessages >= _normalLimit && !mod)
+                    return false;
+            }
+
             RegisterSend(channel);
             return true;
         }
 
-        long unix = DateTimeOffset.Now.ToUnixTimeMilliseconds();
-        int sent = _messages[channel].Count(x => unix - x < 30000);
+        int sent = _messages[channel].Count(x => time - x < 30000);
         int old = _messages[channel].Count - sent;
 
         for (int i = 0; i < old; i++)
@@ -35,9 +46,22 @@ internal sealed class RateLimitManager
             _ = _messages[channel].Dequeue();
         }
 
+        if (_isGlobal)
+        {
+            int gMessages = CalcGlobalMessages(time);
+            if (gMessages >= _modLimit)
+                return false;
+            else if (gMessages >= _normalLimit && !mod)
+                return false;
+
+            RegisterSend(channel);
+            return true;
+        }
+
         if (mod)
         {
-            if (sent < _modC)
+
+            if (sent < _modLimit)
             {
                 RegisterSend(channel);
                 return true;
@@ -46,7 +70,7 @@ internal sealed class RateLimitManager
             return false;
         }
 
-        if (sent < _normalC)
+        if (sent < _normalLimit)
         {
             RegisterSend(channel);
             return true;
@@ -72,7 +96,7 @@ internal sealed class RateLimitManager
             _ = _joins.Dequeue();
         }
 
-        if (attempts < _joinC)
+        if (attempts < _joinLimit)
         {
             RegisterJoin();
             return true;
@@ -84,4 +108,9 @@ internal sealed class RateLimitManager
     private void RegisterSend(string channel) => _messages[channel].Enqueue(DateTimeOffset.Now.ToUnixTimeMilliseconds());
 
     private void RegisterJoin() => _joins.Enqueue(DateTimeOffset.Now.ToUnixTimeMilliseconds());
+
+    private int CalcGlobalMessages(long time)
+    {
+        return _messages.SelectMany(x => x.Value).Count(x => time - x < 30000);
+    }
 }

--- a/MiniTwitch.Irc/Internal/RateLimitManager.cs
+++ b/MiniTwitch.Irc/Internal/RateLimitManager.cs
@@ -109,8 +109,5 @@ internal sealed class RateLimitManager
 
     private void RegisterJoin() => _joins.Enqueue(DateTimeOffset.Now.ToUnixTimeMilliseconds());
 
-    private int CalcGlobalMessages(long time)
-    {
-        return _messages.SelectMany(x => x.Value).Count(x => time - x < 30000);
-    }
+    private int CalcGlobalMessages(long time) => _messages.SelectMany(x => x.Value).Count(x => time - x < 30000);
 }

--- a/MiniTwitch.Irc/Models/ClientOptions.cs
+++ b/MiniTwitch.Irc/Models/ClientOptions.cs
@@ -60,4 +60,10 @@ public sealed class ClientOptions : IMembershipClientOptions
     /// <para>Note: Adding <see cref="IgnoreCommand.USERSTATE"/> to <see cref="IgnoreCommands"/> makes this obsolete</para>
     /// </summary>
     public int ModMessageRateLimit { get; set; } = 100;
+    /// <summary>
+    /// When <see langword="true"/>, <see cref="MessageRateLimit"/> and <see cref="ModMessageRateLimit"/> will be applied globally instead of per channel
+    /// <para>Relevant issue: <see href="https://git.kotmisia.pl/Mm2PL/docs/issues/12"/></para>
+    /// <para>Default value is <see langword="false"/></para>
+    /// </summary>
+    public bool UseGlobalRateLimit { get; set; } = false;
 }

--- a/MiniTwitch.Irc/Models/ClientOptions.cs
+++ b/MiniTwitch.Irc/Models/ClientOptions.cs
@@ -61,9 +61,9 @@ public sealed class ClientOptions : IMembershipClientOptions
     /// </summary>
     public int ModMessageRateLimit { get; set; } = 100;
     /// <summary>
-    /// When <see langword="true"/>, <see cref="MessageRateLimit"/> and <see cref="ModMessageRateLimit"/> will be applied globally instead of per channel
+    /// Applies <see cref="MessageRateLimit"/> and <see cref="ModMessageRateLimit"/> globally instead of per channel
     /// <para>Relevant issue: <see href="https://git.kotmisia.pl/Mm2PL/docs/issues/12"/></para>
-    /// <para>Default value is <see langword="false"/></para>
+    /// <para>Default value is <see langword="true"/></para>
     /// </summary>
-    public bool UseGlobalRateLimit { get; set; } = false;
+    public bool UseGlobalRateLimit { get; set; } = true;
 }


### PR DESCRIPTION
The info regarding message ratelimit buckets in the Twitch documentation is wrong/misleading, see https://git.kotmisia.pl/Mm2PL/docs/issues/12 

This PR adds an option to opt-in the *correct* behavior. Though I'm not sure if it should be opt-in or the default behavior