### PR TITLE
chore: move WebSocket receiver to long-running Task using hint

### DIFF
--- a/MiniTwitch.Common/WebSocketClient.cs
+++ b/MiniTwitch.Common/WebSocketClient.cs
@@ -51,7 +51,7 @@ public sealed class WebSocketClient : IAsyncDisposable
         _uri = uri;
         Log(LogLevel.Trace, "Connecting to {uri} ...", uri);
         await _client.ConnectAsync(uri, cancellationToken);
-        _receiveTask = Receive();
+        _receiveTask = Task.Factory.StartNew(Receive, TaskCreationOptions.LongRunning);
         await Task.Delay(500, cancellationToken);
         if (this.IsConnected)
         {


### PR DESCRIPTION
This PR aims to move the WebSocket message receiver worker to its own thread without actually dealing with the thread, using the `LongRunning` factory hint. This hint should *usually* tell the Task scheduler to hold onto the thread for this specific Task.