### PR TITLE
Fix ReconnectionDelay being always the default value

### DIFF
--- a/MiniTwitch.Irc/Interfaces/IMembershipClientOptions.cs
+++ b/MiniTwitch.Irc/Interfaces/IMembershipClientOptions.cs
@@ -18,4 +18,9 @@ public interface IMembershipClientOptions
     /// <para>Adding a logger is not required, but highly recommended</para>
     /// </summary>
     public ILogger? Logger { get; set; }
+    /// <summary>
+    /// The time to wait before trying to reconnect
+    /// <para>Default value is <see langword="30"/> seconds</para>
+    /// </summary>
+    public TimeSpan ReconnectionDelay { get; set; }
 }

--- a/MiniTwitch.Irc/IrcClient.cs
+++ b/MiniTwitch.Irc/IrcClient.cs
@@ -27,7 +27,9 @@ public sealed class IrcClient : IAsyncDisposable
     public List<IBasicChannel> JoinedChannels { get; } = new();
     /// <summary>
     /// Time to wait before attempting to reconnect to TMI upon disconnection
+    /// <para>Do not use this property to change the reconnection delay. Change <see cref="ClientOptions.ReconnectionDelay"/> in the constructor instead</para>
     /// </summary>
+    [Obsolete("Changing this value does nothing; It will be removed in the future")]
     public TimeSpan ReconnectionDelay { get; init; } = TimeSpan.FromSeconds(30);
 
     internal ClientOptions Options { get; init; }
@@ -161,10 +163,10 @@ public sealed class IrcClient : IAsyncDisposable
     /// </summary>
     public IrcClient(Action<ClientOptions> options)
     {
-        _ws = new WebSocketClient(this.ReconnectionDelay, 2048);
         ClientOptions clientOptions = new();
         options.Invoke(clientOptions);
         this.Options = clientOptions;
+        _ws = new WebSocketClient(this.Options.ReconnectionDelay, 2048);
         _manager = new(clientOptions);
 
         InternalInit();

--- a/MiniTwitch.Irc/IrcClient.cs
+++ b/MiniTwitch.Irc/IrcClient.cs
@@ -242,7 +242,7 @@ public sealed class IrcClient : IAsyncDisposable
     /// <summary>
     /// Disconnects then reconnects to TMI
     /// </summary>
-    public Task ReconnectAsync(CancellationToken cancellationToken = default) => _ws.Restart(this.ReconnectionDelay, cancellationToken);
+    public Task ReconnectAsync(CancellationToken cancellationToken = default) => _ws.Restart(this.Options.ReconnectionDelay, cancellationToken);
 
     private async Task OnWsReconnect()
     {
@@ -530,7 +530,7 @@ public sealed class IrcClient : IAsyncDisposable
 
             case IrcCommand.RECONNECT:
                 Log(LogLevel.Information, "Twitch servers requested a reconnection. Reconnecting ...");
-                _ws.Restart(this.ReconnectionDelay).StepOver();
+                _ws.Restart(this.Options.ReconnectionDelay).StepOver();
                 OnReconnect?.Invoke().StepOver(this.ExceptionHandler);
                 break;
 

--- a/MiniTwitch.Irc/IrcMembershipClient.cs
+++ b/MiniTwitch.Irc/IrcMembershipClient.cs
@@ -21,7 +21,7 @@ public sealed class IrcMembershipClient : IAsyncDisposable
 
     #region Properties
     /// <summary>
-    /// 
+    /// The action to invoke when an exception is caught within an event
     /// </summary>
     public Action<Exception> ExceptionHandler { get; set; } = default!;
     #endregion
@@ -56,7 +56,7 @@ public sealed class IrcMembershipClient : IAsyncDisposable
     private readonly SemaphoreSlim _connectionWaiter = new(0);
     private readonly SemaphoreSlim _joinChannelWaiter = new(0);
     private readonly IMembershipClientOptions _options;
-    private readonly WebSocketClient _ws = new(TimeSpan.FromSeconds(30), 8192);
+    private readonly WebSocketClient _ws;
     private readonly List<string> _joinedChannels = new();
     private readonly RateLimitManager _manager;
     private bool _connectInvoked;
@@ -71,6 +71,7 @@ public sealed class IrcMembershipClient : IAsyncDisposable
         var clientOptions = new ClientOptions();
         options(clientOptions);
         _options = clientOptions;
+        _ws = new(_options.ReconnectionDelay, 8192);
         _manager = new(clientOptions);
 
         InternalInt();

--- a/MiniTwitch.Irc/IrcMembershipClient.cs
+++ b/MiniTwitch.Irc/IrcMembershipClient.cs
@@ -99,7 +99,7 @@ public sealed class IrcMembershipClient : IAsyncDisposable
     }
 
     /// <summary>
-    /// Attempts connection to TMI like <see cref="ConnectAsync()"/>, but connects in a "fire and forget" style
+    /// Attempts connection to TMI like <see cref="ConnectAsync(CancellationToken)"/>, but connects in a "fire and forget" style
     /// </summary>
     public void Connect() => ConnectAsync().StepOver();
 
@@ -107,13 +107,13 @@ public sealed class IrcMembershipClient : IAsyncDisposable
     /// Connects to TMI
     /// </summary>
     /// <returns><see langword="true"/> if the connection is successful; Otherwise, after 15 seconds: <see langword="false"/></returns>
-    public async Task<bool> ConnectAsync()
+    public async Task<bool> ConnectAsync(CancellationToken cancellationToken = default)
     {
         Uri uri = new(CONN_URL);
 
-        await _ws.Start(uri);
+        await _ws.Start(uri, cancellationToken);
 
-        if (await _connectionWaiter.WaitAsync(TimeSpan.FromSeconds(15)).ConfigureAwait(false))
+        if (await _connectionWaiter.WaitAsync(TimeSpan.FromSeconds(15), cancellationToken).ConfigureAwait(false))
             return true;
 
         Log(LogLevel.Critical, "Connection timed out.");
@@ -128,7 +128,12 @@ public sealed class IrcMembershipClient : IAsyncDisposable
     /// <summary>
     /// Disconnects from TMI
     /// </summary>
-    public Task DisconnectAsync() => _ws.Disconnect();
+    public Task DisconnectAsync(CancellationToken cancellationToken = default) => _ws.Disconnect(cancellationToken);
+
+    /// <summary>
+    /// Disconnects then reconnects to TMI
+    /// </summary>
+    public Task ReconnectAsync(CancellationToken cancellationToken = default) => _ws.Restart(_options.ReconnectionDelay, cancellationToken);
 
     private async Task OnWsReconnect()
     {
@@ -256,7 +261,7 @@ public sealed class IrcMembershipClient : IAsyncDisposable
 
             case IrcCommand.RECONNECT:
                 Log(LogLevel.Information, "Twitch servers requested a reconnection. Reconnecting ...");
-                _ws.Restart(TimeSpan.FromSeconds(30)).StepOver();
+                _ws.Restart(_options.ReconnectionDelay).StepOver();
                 OnReconnect?.Invoke().StepOver(this.ExceptionHandler);
                 break;
 

--- a/MiniTwitch.Irc/Models/ClientOptions.cs
+++ b/MiniTwitch.Irc/Models/ClientOptions.cs
@@ -66,4 +66,9 @@ public sealed class ClientOptions : IMembershipClientOptions
     /// <para>Default value is <see langword="true"/></para>
     /// </summary>
     public bool UseGlobalRateLimit { get; set; } = true;
+    /// <summary>
+    /// The time to wait before trying to reconnect
+    /// <para>Default value is <see langword="30"/> seconds</para>
+    /// </summary>
+    public TimeSpan ReconnectionDelay { get; set; } = TimeSpan.FromSeconds(30);
 }


### PR DESCRIPTION
Because the WebSocketClient was being created in the constructor, the value of ReconnectionDelay was always the default (30 seconds)

Since it was only modifiable in the accessor which is called later than the constructor, changing the value never did anything. So I decided to deprecate it and move it to ClientOptions


Code used to test constructor/accessor calls:
```csharp
Forsen a = new()
{
    Property = "xD"
};

public class Forsen
{
    private string _field = "a";

    public string Property
    {
        init
        {
            Console.WriteLine("property init");
            _field = value;
        }
    }

    public Forsen()
    {
        Console.WriteLine("ctor");
    }
}
```

output:
```
ctor
property init
```