### PR TITLE
Fix enumerator alloc + mark with forceinline

### DIFF
--- a/MiniTwitch.Irc/Internal/Models/IrcTags.cs
+++ b/MiniTwitch.Irc/Internal/Models/IrcTags.cs
@@ -1,9 +1,10 @@
 ﻿using System.Buffers;
 using System.Collections;
+using System.Runtime.CompilerServices;
 
 namespace MiniTwitch.Irc.Internal.Models;
 
-internal readonly struct IrcTags : IDisposable, IEnumerable
+internal readonly struct IrcTags : IDisposable
 {
     public int Count { get; }
     private IrcTag[] Tags { get; }
@@ -16,15 +17,9 @@ internal readonly struct IrcTags : IDisposable, IEnumerable
 
     public void Dispose() => ArrayPool<IrcTag>.Shared.Return(this.Tags, true);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Add(int index, ReadOnlyMemory<byte> Key, ReadOnlyMemory<byte> Value) => this.Tags[index] = new(Key, Value);
 
-    public IEnumerator<IrcTag> GetEnumerator()
-    {
-        for (int x = 0; x < this.Count; x++)
-        {
-            yield return this.Tags[x];
-        }
-    }
-
-    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Span<IrcTag>.Enumerator GetEnumerator() => this.Tags.AsSpan(0, this.Count).GetEnumerator();
 }


### PR DESCRIPTION
Up to 15% speed up to `MiniTwitch.Process` for free

Was
```txt
BenchmarkDotNet=v0.13.5, OS=macOS Ventura 13.4 (22F66) [Darwin 22.5.0]
Apple M1 Pro, 1 CPU, 8 logical and 8 physical cores
.NET SDK=8.0.100-preview.6.23307.25
  [Host]                 : .NET 8.0.0 (8.0.23.30704), Arm64 RyuJIT AdvSIMD
  ShortRun               : .NET 8.0.0 (8.0.23.30704), Arm64 RyuJIT AdvSIMD
  ShortRun-NativeAOT 8.0 : .NET 8.0.0-preview.6.23307.4, Arm64 NativeAOT AdvSIMD

IterationCount=3  LaunchCount=1  WarmupCount=3  

|          Method |                    Job |       Runtime |     Mean |     Error |    StdDev |     Gen0 | Allocated |
|---------------- |----------------------- |-------------- |---------:|----------:|----------:|---------:|----------:|
| MiniTwitchParse |               ShortRun |      .NET 8.0 | 1.617 ms | 0.1861 ms | 0.0102 ms | 224.6094 |   1.35 MB |
| MiniTwitchParse | ShortRun-NativeAOT 8.0 | NativeAOT 8.0 | 1.459 ms | 0.0389 ms | 0.0021 ms | 224.6094 |   1.35 MB |
```
Now
```
BenchmarkDotNet=v0.13.5, OS=macOS Ventura 13.4 (22F66) [Darwin 22.5.0]
Apple M1 Pro, 1 CPU, 8 logical and 8 physical cores
.NET SDK=8.0.100-preview.6.23307.25
  [Host]        : .NET 8.0.0 (8.0.23.30704), Arm64 RyuJIT AdvSIMD
  DefaultJob    : .NET 8.0.0 (8.0.23.30704), Arm64 RyuJIT AdvSIMD
  NativeAOT 8.0 : .NET 8.0.0-preview.6.23307.4, Arm64 NativeAOT AdvSIMD


|          Method |           Job |       Runtime |     Mean |     Error |    StdDev |     Gen0 | Allocated |
|---------------- |-------------- |-------------- |---------:|----------:|----------:|---------:|----------:|
| MiniTwitchParse |    DefaultJob |      .NET 8.0 | 1.402 ms | 0.0030 ms | 0.0028 ms | 212.8906 |   1.28 MB |
| MiniTwitchParse | NativeAOT 8.0 | NativeAOT 8.0 | 1.285 ms | 0.0046 ms | 0.0043 ms | 212.8906 |   1.28 MB |
```

p.s.: if you're feeling adventurous might switch to pointers with `ref` because all these span slices will sadly have bounds checks all over the place which probably hurts the throughput
p.s.: first benchmark I see to actually perform better with AOT 🤯