### PR TITLE
Decrease task delays according to configured ratelimit

### DIFF
--- a/MiniTwitch.Irc/IrcClient.cs
+++ b/MiniTwitch.Irc/IrcClient.cs
@@ -247,8 +247,8 @@ public sealed class IrcClient : IAsyncDisposable
     private async Task OnWsReconnect()
     {
         await Login();
-        TimeSpan joinInterval = this.JoinedChannels.Count >= this.Options.JoinRateLimit 
-            ? TimeSpan.FromSeconds(this.JoinedChannels.Count * (10 / this.Options.JoinRateLimit)) 
+        TimeSpan joinInterval = this.JoinedChannels.Count >= this.Options.JoinRateLimit
+            ? TimeSpan.FromSeconds(this.JoinedChannels.Count * (10 / this.Options.JoinRateLimit))
             : TimeSpan.Zero;
 
         foreach (string channel in this.JoinedChannels.Select(c => c.Name))
@@ -312,11 +312,13 @@ public sealed class IrcClient : IAsyncDisposable
 
         if (!_manager.CanSend(channel, _moderated.Contains(channel)))
         {
-            await Task.Delay(TimeSpan.FromSeconds(90 / this.Options.MessageRateLimit), cancellationToken);
-            await SendMessage(channel, message, action, nonce, cancellationToken);
-            Log(LogLevel.Debug, "Cannot send message to #{channel}: Rate limit of {count} hit. Retrying in {delay}ms", channel, this.Options.ModMessageRateLimit, 2500);
+            TimeSpan delay = TimeSpan.FromSeconds(90 / this.Options.MessageRateLimit);
+            Log(LogLevel.Debug, "Cannot send message to #{channel}: Rate limit of {count} hit. Retrying in {delay}s",
+                channel, this.Options.ModMessageRateLimit, delay.TotalSeconds);
             Log(LogLevel.Warning, "#{channel}: Your message was not sent yet due to the configured messaging ratelimit (normal: {normal}/30s, mod: {mod}/30s)",
                 channel, this.Options.MessageRateLimit, this.Options.ModMessageRateLimit);
+            await Task.Delay(delay, cancellationToken);
+            await SendMessage(channel, message, action, nonce, cancellationToken);
             return;
         }
 
@@ -347,11 +349,13 @@ public sealed class IrcClient : IAsyncDisposable
         string channel = parentMessage.Channel.Name;
         if (!_manager.CanSend(channel, _moderated.Contains(channel)))
         {
-            await Task.Delay(TimeSpan.FromSeconds(90 / this.Options.MessageRateLimit), cancellationToken);
-            await ReplyTo(parentMessage, message, action, cancellationToken);
-            Log(LogLevel.Debug, "Cannot send message to #{channel}: Rate limit of {count} hit. Retrying in {delay}ms", channel, this.Options.ModMessageRateLimit, 2500);
+            TimeSpan delay = TimeSpan.FromSeconds(90 / this.Options.MessageRateLimit);
+            Log(LogLevel.Debug, "Cannot send message to #{channel}: Rate limit of {count} hit. Retrying in {delay}s",
+                channel, this.Options.ModMessageRateLimit, delay.TotalSeconds);
             Log(LogLevel.Warning, "#{channel}: Your message was not sent yet due to the configured messaging ratelimit (normal: {normal}/30s, mod: {mod}/30s)",
                 channel, this.Options.MessageRateLimit, this.Options.ModMessageRateLimit);
+            await Task.Delay(delay, cancellationToken);
+            await ReplyTo(parentMessage, message, action, cancellationToken);
             return;
         }
 
@@ -386,11 +390,13 @@ public sealed class IrcClient : IAsyncDisposable
 
         if (!_manager.CanSend(channel, _moderated.Contains(channel)))
         {
-            await Task.Delay(TimeSpan.FromSeconds(90 / this.Options.MessageRateLimit), cancellationToken);
-            await ReplyTo(messageId, channel, reply, action, cancellationToken);
-            Log(LogLevel.Debug, "Cannot send message to #{channel}: Rate limit of {count} hit. Retrying in {delay}ms", channel, this.Options.ModMessageRateLimit, 2500);
+            TimeSpan delay = TimeSpan.FromSeconds(90 / this.Options.MessageRateLimit);
+            Log(LogLevel.Debug, "Cannot send message to #{channel}: Rate limit of {count} hit. Retrying in {delay}s",
+                channel, this.Options.ModMessageRateLimit, delay.TotalSeconds);
             Log(LogLevel.Warning, "#{channel}: Your message was not sent yet due to the configured messaging ratelimit (normal: {normal}/30s, mod: {mod}/30s)",
                 channel, this.Options.MessageRateLimit, this.Options.ModMessageRateLimit);
+            await Task.Delay(delay, cancellationToken);
+            await ReplyTo(messageId, channel, reply, action, cancellationToken);
             return;
         }
 
@@ -423,8 +429,8 @@ public sealed class IrcClient : IAsyncDisposable
 
         if (!_manager.CanJoin())
         {
-            await Task.Delay(TimeSpan.FromSeconds(30 / this.Options.JoinRateLimit), cancellationToken);
             Log(LogLevel.Warning, "Waiting to join #{channel}: Configured ratelimit of {rate} joins/10s is hit", channel, this.Options.JoinRateLimit);
+            await Task.Delay(TimeSpan.FromSeconds(30 / this.Options.JoinRateLimit), cancellationToken);
             return await JoinChannel(channel, cancellationToken);
         }
 

--- a/MiniTwitch.Irc/IrcMembershipClient.cs
+++ b/MiniTwitch.Irc/IrcMembershipClient.cs
@@ -138,10 +138,14 @@ public sealed class IrcMembershipClient : IAsyncDisposable
     private async Task OnWsReconnect()
     {
         await Login();
+        TimeSpan joinInterval = _joinedChannels.Count >= _options.JoinRateLimit
+            ? TimeSpan.FromSeconds(_joinedChannels.Count * (10 / _options.JoinRateLimit))
+            : TimeSpan.Zero;
+
         foreach (string channel in _joinedChannels)
         {
             await JoinChannel(channel);
-            await Task.Delay(1000);
+            await Task.Delay(joinInterval);
         }
     }
 
@@ -177,7 +181,7 @@ public sealed class IrcMembershipClient : IAsyncDisposable
 
         if (!_manager.CanJoin())
         {
-            await Task.Delay(2500);
+            await Task.Delay(TimeSpan.FromSeconds(30 / _options.JoinRateLimit), cancellationToken);
             Log(LogLevel.Warning, "Waiting to join #{channel}: Configured ratelimit of {rate} joins/10s is hit", channel, _options.JoinRateLimit);
             await JoinChannel(channel, cancellationToken);
             return;

--- a/MiniTwitch.Irc/IrcMembershipClient.cs
+++ b/MiniTwitch.Irc/IrcMembershipClient.cs
@@ -181,8 +181,8 @@ public sealed class IrcMembershipClient : IAsyncDisposable
 
         if (!_manager.CanJoin())
         {
-            await Task.Delay(TimeSpan.FromSeconds(30 / _options.JoinRateLimit), cancellationToken);
             Log(LogLevel.Warning, "Waiting to join #{channel}: Configured ratelimit of {rate} joins/10s is hit", channel, _options.JoinRateLimit);
+            await Task.Delay(TimeSpan.FromSeconds(30 / _options.JoinRateLimit), cancellationToken);
             await JoinChannel(channel, cancellationToken);
             return;
         }


### PR DESCRIPTION
Instead of having a fixed delays for hitting join/message ratelimits, the delays will now depend on the configured ratelimit values in `ClientOptions`

This PR also speeds up the process of rejoining channels upon reconnecting