### PR TITLE
Add support for new PRIVMSG reply tags

### DIFF
--- a/MiniTwitch.Irc/Models/MessageReply.cs
+++ b/MiniTwitch.Irc/Models/MessageReply.cs
@@ -26,6 +26,16 @@ public readonly struct MessageReply
     /// </summary>
     public long ParentUserId { get; init; }
     /// <summary>
+    /// ID of the first message in the thread of the replied-to message
+    /// <para>This value is equal to <see cref="ParentMessageId"/> if the replied-to message is not in a thread</para>
+    /// </summary>
+    public string ParentThreadMessageId { get; init; }
+    /// <summary>
+    /// Username of the first message's author in the thread of the replied-to message
+    /// <para>This value is equal to <see cref="ParentUsername"/> if the replied-to message is not in a thread</para>
+    /// </summary>
+    public string ParentThreadUsername { get; init; }
+    /// <summary>
     /// Whether there are reply contents in this message
     /// </summary>
     public bool HasContent { get; init; }

--- a/MiniTwitch.Irc/Models/MessageReply.cs
+++ b/MiniTwitch.Irc/Models/MessageReply.cs
@@ -6,23 +6,23 @@
 public readonly struct MessageReply
 {
     /// <summary>
-    /// Display name of the original message's author
+    /// Display name of the replied-to message's author
     /// </summary>
     public string ParentDisplayName { get; init; }
     /// <summary>
-    /// Content of the original message
+    /// Content of the replied-to message
     /// </summary>
     public string ParentMessage { get; init; }
     /// <summary>
-    /// Unique ID to identify the original message
+    /// Unique ID to identify the replied-to message
     /// </summary>
     public string ParentMessageId { get; init; }
     /// <summary>
-    /// Name of the original message's author
+    /// Name of the replied-to message's author
     /// </summary>
     public string ParentUsername { get; init; }
     /// <summary>
-    /// ID of the original message's author
+    /// ID of the replied-to message's author
     /// </summary>
     public long ParentUserId { get; init; }
     /// <summary>

--- a/MiniTwitch.Irc/Models/Privmsg.cs
+++ b/MiniTwitch.Irc/Models/Privmsg.cs
@@ -101,6 +101,8 @@ public readonly struct Privmsg : IUnixTimestamped, IEquatable<Privmsg>
         string replyMessageBody = string.Empty;
         string replyUsername = string.Empty;
         string replyDisplayName = string.Empty;
+        string threadParentMessageid = string.Empty;
+        string threadParentUsername = string.Empty;
 
         // IBasicChannel
         string channelName = memory.Span.FindChannel();
@@ -245,6 +247,16 @@ public readonly struct Privmsg : IUnixTimestamped, IEquatable<Privmsg>
                 case 2516:
                     replyDisplayName = TagHelper.GetString(tagValue);
                     break;
+
+                //reply-thread-parent-msg-id
+                case 2550:
+                    threadParentMessageid = TagHelper.GetString(tagValue);
+                    break;
+
+                //reply-thread-parent-user-login
+                case 3002:
+                    threadParentUsername = TagHelper.GetString(tagValue);
+                    break;
             }
         }
 
@@ -269,6 +281,8 @@ public readonly struct Privmsg : IUnixTimestamped, IEquatable<Privmsg>
             ParentMessage = replyMessageBody,
             ParentUserId = replyUserId,
             ParentUsername = replyUsername,
+            ParentThreadMessageId = threadParentMessageid,
+            ParentThreadUsername = threadParentUsername,
             HasContent = hasReply
         };
         this.Channel = new IrcChannel()


### PR DESCRIPTION
New tags spotted in reply messages:
`reply-thread-parent-msg-id`
`reply-thread-parent-user-login`

While the values of these tags can seem like a duplicate of `reply-parent-msg-id` and `reply-parent-user-login`, they are not the same, as they refer to the thread that the replied-to message is in. If the replied-to message is not in a thread, then their values is a copy of the other tags

See image for better explanation:
![image](https://github.com/Foretack/MiniTwitch/assets/69414142/16c211cc-6dd7-4ef6-94f8-3cbfcfe4ba69)

