### PR TITLE
Vectorize `ReadOnlySpan<byte>.Sum()` when possible (Avx2)

### DIFF
--- a/MiniTwitch.Common/MiniTwitch.Common.csproj
+++ b/MiniTwitch.Common/MiniTwitch.Common.csproj
@@ -17,6 +17,7 @@
       <Version>1.0.3</Version>
       <PackageLicenseFile>LICENSE</PackageLicenseFile>
       <PackageIconUrl>https://media.occluder.space/f/common.png</PackageIconUrl>
+      <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This should be a simple change to bring the method's speed up to compete with SequenceEquals (for spans tags at least)