### PR TITLE
Deprecate `string ColorCode` property in favor of `Color ChatColor`

### DIFF
--- a/MiniTwitch.Irc.Test/MessageAuthorTests.cs
+++ b/MiniTwitch.Irc.Test/MessageAuthorTests.cs
@@ -14,7 +14,7 @@ public class MessageAuthorTests
 
         Assert.Equal("subscriber/42", author.BadgeInfo);
         Assert.Equal("subscriber/42,glhf-pledge/1", author.Badges);
-        Assert.Equal("#F97304", author.ColorCode);
+        Assert.Equal("f97304", author.ChatColor.Name);
         Assert.Equal("zneix", author.DisplayName);
         Assert.Equal("zneix", author.Name);
         Assert.Equal(99631238, author.Id);
@@ -41,7 +41,7 @@ public class MessageAuthorTests
 
         Assert.Equal(default, author.BadgeInfo);
         Assert.Equal(default, author.Badges);
-        Assert.Equal(default, author.ColorCode);
+        Assert.Equal(default, author.ChatColor);
         Assert.Equal(default, author.DisplayName);
         Assert.Equal(default, author.Type);
     }
@@ -55,7 +55,7 @@ public class MessageAuthorTests
 
         Assert.Equal(string.Empty, author.BadgeInfo);
         Assert.Equal("broadcaster/1", author.Badges);
-        Assert.Equal("#F2647B", author.ColorCode);
+        Assert.Equal("f2647b", author.ChatColor.Name);
         Assert.Equal("occluder", author.Name);
         Assert.Equal("occluder", author.DisplayName);
         Assert.Equal(UserType.None, author.Type);
@@ -78,7 +78,7 @@ public class MessageAuthorTests
 
         Assert.Equal(default, author.BadgeInfo);
         Assert.Equal(default, author.Badges);
-        Assert.Equal(default, author.ColorCode);
+        Assert.Equal(default, author.ChatColor);
         Assert.Equal(default, author.DisplayName);
         Assert.Equal(default, author.IsSubscriber);
         Assert.Equal(default, author.IsTurbo);
@@ -96,7 +96,7 @@ public class MessageAuthorTests
         var author = (MessageAuthor)whisper.Author;
 
         Assert.Equal(string.Empty, author.Badges);
-        Assert.Equal("#2E8B57", author.ColorCode);
+        Assert.Equal("2e8b57", author.ChatColor.Name);
         Assert.Equal("pajbot", author.DisplayName);
         Assert.Equal("pajbot", author.Name);
         Assert.Equal(82008718, author.Id);
@@ -118,7 +118,7 @@ public class MessageAuthorTests
 
         Assert.Equal("subscriber/13", author.BadgeInfo);
         Assert.Equal("subscriber/12,premium/1", author.Badges);
-        Assert.Equal("#0000FF", author.ColorCode);
+        Assert.Equal("ff", author.ChatColor.Name);
         Assert.Equal("Goop_456789", author.DisplayName);
         Assert.Equal("goop_456789", author.Name);
         Assert.Equal(93668177, author.Id);

--- a/MiniTwitch.Irc/Interfaces/IUserstateSelf.cs
+++ b/MiniTwitch.Irc/Interfaces/IUserstateSelf.cs
@@ -1,4 +1,5 @@
-﻿using MiniTwitch.Irc.Enums;
+﻿using System.Drawing;
+using MiniTwitch.Irc.Enums;
 using MiniTwitch.Irc.Models;
 
 namespace MiniTwitch.Irc.Interfaces;
@@ -13,7 +14,10 @@ public interface IUserstateSelf
     /// <inheritdoc cref="MessageAuthor.Badges"/>
     string Badges { get; }
     /// <inheritdoc cref="MessageAuthor.ColorCode"/>
+    [Obsolete("Use the 'ChatColor' property instead. This property will be removed in a future version")]
     string ColorCode { get; }
+    /// <inheritdoc cref="MessageAuthor.ChatColor"/>
+    Color ChatColor { get; }
     /// <summary>
     /// Your username
     /// </summary>

--- a/MiniTwitch.Irc/Interfaces/IWhisperAuthor.cs
+++ b/MiniTwitch.Irc/Interfaces/IWhisperAuthor.cs
@@ -1,4 +1,5 @@
-﻿using MiniTwitch.Irc.Enums;
+﻿using System.Drawing;
+using MiniTwitch.Irc.Enums;
 using MiniTwitch.Irc.Models;
 
 namespace MiniTwitch.Irc.Interfaces;
@@ -11,7 +12,10 @@ public interface IWhisperAuthor
     /// <inheritdoc cref="MessageAuthor.Badges"/>
     string Badges { get; }
     /// <inheritdoc cref="MessageAuthor.ColorCode"/>
+    [Obsolete("Use the 'ChatColor' property instead. This property will be removed in a future version")]
     string ColorCode { get; }
+    /// <inheritdoc cref="MessageAuthor.ChatColor"/>
+    Color ChatColor { get; }
     /// <inheritdoc cref="MessageAuthor.DisplayName"/>
     string DisplayName { get; }
     /// <inheritdoc cref="MessageAuthor.Name"/>

--- a/MiniTwitch.Irc/Internal/Parsing/TagHelper.cs
+++ b/MiniTwitch.Irc/Internal/Parsing/TagHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Drawing;
+using System.Text;
 using MiniTwitch.Common.Extensions;
 
 namespace MiniTwitch.Irc.Internal.Parsing;
@@ -71,6 +72,25 @@ internal static class TagHelper
         }
 
         return Enum.Parse<TEnum>(interned, true);
+    }
+
+    public static Color GetColor(ReadOnlySpan<byte> hexBytes)
+    {
+        const byte zero = (byte)'0';
+        const byte nine = (byte)'9';
+        const byte leading = (byte)'#';
+        const byte A = (byte)'A';
+
+        int hexValue = 0;
+        foreach (byte b in hexBytes)
+        {
+            if (b == leading)
+                continue;
+
+            hexValue = (hexValue << 4) | (b is >= zero and <= nine ? b - zero : (b & 0x4F) - A + 10);
+        }
+
+        return Color.FromArgb(hexValue);
     }
 
     private static int ParseInt(ReadOnlySpan<byte> span)

--- a/MiniTwitch.Irc/Models/MessageAuthor.cs
+++ b/MiniTwitch.Irc/Models/MessageAuthor.cs
@@ -1,4 +1,5 @@
-﻿using MiniTwitch.Irc.Enums;
+﻿using System.Drawing;
+using MiniTwitch.Irc.Enums;
 using MiniTwitch.Irc.Interfaces;
 
 namespace MiniTwitch.Irc.Models;
@@ -29,10 +30,16 @@ public readonly struct MessageAuthor : IBanTarget, IDeletedMessageAuthor, IWhisp
     /// </summary>
     public string Badges { get; init; }
     /// <summary>
-    /// The color of the user’s name in the chat room. This is a hexadecimal RGB color code in the form, #RGB
-    /// <para>Note: May be empty if it is never set</para>
+    /// The color of the user’s name in the chat room
+    /// <para>This property is deprecated and will be removed in a future version</para>
+    /// <para>Use <see cref="ChatColor"/> instead</para>
     /// </summary>
-    public string ColorCode { get; init; }
+    [Obsolete("Use the 'ChatColor' property instead. This property will be removed in a future version")]
+    public string ColorCode => ChatColor.Name;
+    /// <summary>
+    /// The color of the user’s name in the chat room
+    /// </summary>
+    public Color ChatColor { get; init; }
     /// <summary>
     /// The user’s display name, escaped as described in the <see href="https://ircv3.net/specs/core/message-tags-3.2.html">IRCv3</see> spec
     /// <para>Note: Can contain characters outside [a-zA-Z0-9_]</para>

--- a/MiniTwitch.Irc/Models/Privmsg.cs
+++ b/MiniTwitch.Irc/Models/Privmsg.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Drawing;
 using System.Text;
 using MiniTwitch.Common.Extensions;
 using MiniTwitch.Irc.Enums;
@@ -84,7 +85,7 @@ public readonly struct Privmsg : IUnixTimestamped, IEquatable<Privmsg>
         // MessageAuthor
         string badges = string.Empty;
         string badgeInfo = string.Empty;
-        string color = string.Empty;
+        Color color = default;
         string displayName = string.Empty;
         string username = memory.Span.FindUsername();
         long uid = 0;
@@ -154,7 +155,7 @@ public readonly struct Privmsg : IUnixTimestamped, IEquatable<Privmsg>
 
                 //color
                 case 543:
-                    color = TagHelper.GetString(tagValue, true);
+                    color = TagHelper.GetColor(tagValue);
                     break;
 
                 //turbo
@@ -264,7 +265,7 @@ public readonly struct Privmsg : IUnixTimestamped, IEquatable<Privmsg>
         {
             BadgeInfo = badgeInfo,
             Badges = badges,
-            ColorCode = color,
+            ChatColor = color,
             DisplayName = displayName,
             Id = uid,
             IsMod = mod,

--- a/MiniTwitch.Irc/Models/Usernotice.cs
+++ b/MiniTwitch.Irc/Models/Usernotice.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Drawing;
+using System.Text;
 using MiniTwitch.Common.Extensions;
 using MiniTwitch.Irc.Enums;
 using MiniTwitch.Irc.Interfaces;
@@ -71,7 +72,7 @@ public readonly struct Usernotice : IGiftSubNoticeIntro, IAnnouncementNotice, IP
     {
         // Author
         bool isMod = false;
-        string colorCode = string.Empty;
+        Color colorCode = default;
         string badges = string.Empty;
         long userId = 0;
         UserType userType = UserType.None;
@@ -139,7 +140,7 @@ public readonly struct Usernotice : IGiftSubNoticeIntro, IAnnouncementNotice, IP
 
                 //color
                 case 543:
-                    colorCode = TagHelper.GetString(tagValue, true);
+                    colorCode = TagHelper.GetColor(tagValue);
                     break;
 
                 //turbo 
@@ -293,7 +294,7 @@ public readonly struct Usernotice : IGiftSubNoticeIntro, IAnnouncementNotice, IP
         {
             BadgeInfo = badgeInfo,
             Badges = badges,
-            ColorCode = colorCode,
+            ChatColor = colorCode,
             DisplayName = displayName,
             Id = userId,
             IsMod = isMod,

--- a/MiniTwitch.Irc/Models/Userstate.cs
+++ b/MiniTwitch.Irc/Models/Userstate.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Drawing;
+using System.Text;
 using MiniTwitch.Common.Extensions;
 using MiniTwitch.Irc.Enums;
 using MiniTwitch.Irc.Interfaces;
@@ -37,7 +38,7 @@ public readonly struct Userstate
 
         string badgeInfo = string.Empty;
         string badges = string.Empty;
-        string color = string.Empty;
+        Color color = default;
         string displayName = string.Empty;
         bool mod = false;
         bool vip = false;
@@ -72,7 +73,7 @@ public readonly struct Userstate
 
                 //color
                 case 543:
-                    color = TagHelper.GetString(tagValue, true);
+                    color = TagHelper.GetColor(tagValue);
                     break;
 
                 //turbo
@@ -115,7 +116,7 @@ public readonly struct Userstate
         this.Self = new MessageAuthor()
         {
             BadgeInfo = badgeInfo,
-            ColorCode = color,
+            ChatColor = color,
             Badges = badges,
             Name = this.Source?.Options.Username ?? displayName.ToLower(),
             DisplayName = displayName,

--- a/MiniTwitch.Irc/Models/Whisper.cs
+++ b/MiniTwitch.Irc/Models/Whisper.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Drawing;
+using System.Text;
 using MiniTwitch.Common.Extensions;
 using MiniTwitch.Irc.Enums;
 using MiniTwitch.Irc.Interfaces;
@@ -36,7 +37,7 @@ public readonly struct Whisper
     internal Whisper(ReadOnlyMemory<byte> memory)
     {
         string badges = string.Empty;
-        string color = string.Empty;
+        Color color = default;
         string displayName = string.Empty;
         string username = memory.Span.FindUsername();
         long uid = 0;
@@ -57,7 +58,7 @@ public readonly struct Whisper
             {
                 //color
                 case 543:
-                    color = TagHelper.GetString(tagValue, true);
+                    color = TagHelper.GetColor(tagValue);
                     break;
 
                 //turbo
@@ -105,7 +106,7 @@ public readonly struct Whisper
         this.Author = new MessageAuthor()
         {
             Badges = badges,
-            ColorCode = color,
+            ChatColor = color,
             DisplayName = displayName,
             Name = username,
             Id = uid,


### PR DESCRIPTION
This approach allocates 0 memory and is faster while also providing a better API for color codes