### PR TITLE
fix(45): prevent cancellation of disposed CancellationTokenSource on PubSubClient dispose

### DIFF
--- a/MiniTwitch.PubSub/PubSubClient.cs
+++ b/MiniTwitch.PubSub/PubSubClient.cs
@@ -469,7 +469,6 @@ public sealed class PubSubClient : IAsyncDisposable
     {
         Log(LogLevel.Warning, "Disconnected");
         _pingerToken.Cancel();
-        Log(LogLevel.Trace, "Pinger task disposed");
         OnDisconnect?.Invoke().StepOver(GetExceptionHandler());
         return Task.CompletedTask;
     }

--- a/MiniTwitch.PubSub/PubSubClient.cs
+++ b/MiniTwitch.PubSub/PubSubClient.cs
@@ -485,16 +485,13 @@ public sealed class PubSubClient : IAsyncDisposable
         OnReconnect?.Invoke().StepOver(GetExceptionHandler());
     }
 
-    private Task PingerTask()
+    private async Task PingerTask()
     {
-        return Task.Run(async () =>
+        while (_ws.IsConnected && !_pingerToken.IsCancellationRequested)
         {
-            while (_ws.IsConnected && !_pingerToken.IsCancellationRequested)
-            {
-                await Ping();
-                await Task.Delay(TimeSpan.FromMinutes(4), _pingerToken.Token);
-            }
-        }, _pingerToken.Token);
+            await Ping();
+            await Task.Delay(TimeSpan.FromMinutes(4), _pingerToken.Token);
+        }
     }
     #endregion
 

--- a/MiniTwitch.PubSub/PubSubClient.cs
+++ b/MiniTwitch.PubSub/PubSubClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 using MiniTwitch.Common;
@@ -469,7 +469,6 @@ public sealed class PubSubClient : IAsyncDisposable
     {
         Log(LogLevel.Warning, "Disconnected");
         _pingerToken.Cancel();
-        _pinger.Dispose();
         Log(LogLevel.Trace, "Pinger task disposed");
         _pingerToken.Dispose();
         OnDisconnect?.Invoke().StepOver(GetExceptionHandler());

--- a/MiniTwitch.PubSub/PubSubClient.cs
+++ b/MiniTwitch.PubSub/PubSubClient.cs
@@ -470,7 +470,6 @@ public sealed class PubSubClient : IAsyncDisposable
         Log(LogLevel.Warning, "Disconnected");
         _pingerToken.Cancel();
         Log(LogLevel.Trace, "Pinger task disposed");
-        _pingerToken.Dispose();
         OnDisconnect?.Invoke().StepOver(GetExceptionHandler());
         return Task.CompletedTask;
     }

--- a/MiniTwitch.PubSub/PubSubClient.cs
+++ b/MiniTwitch.PubSub/PubSubClient.cs
@@ -492,7 +492,7 @@ public sealed class PubSubClient : IAsyncDisposable
             while (_ws.IsConnected && !_pingerToken.IsCancellationRequested)
             {
                 await Ping();
-                await Task.Delay(TimeSpan.FromMinutes(4));
+                await Task.Delay(TimeSpan.FromMinutes(4), _pingerToken.Token);
             }
         }, _pingerToken.Token);
     }


### PR DESCRIPTION
This PR fixes #45 where a `CancellationTokenSource` was being cancelled after the source was disposed, causing an `ObjectDisposedException` to be thrown on the `PubSubClient`'s dispose handler.

This was caused by the web socket disconnect event handler internally disposing of both the `CancellationTokenSource` `_pingerToken` and its consuming `Task` (which would've been the next issue as it was double disposed) - which is called during the client's disposal prior to trying to dispose of the tokens.

I didn't realise I'd committed a whitespace change but take it!