### PR TITLE
Add a semaphore for receiving data through WebSocket

### DIFF
--- a/MiniTwitch.Common/CHANGELOG.md
+++ b/MiniTwitch.Common/CHANGELOG.md
@@ -1,0 +1,5 @@
+# MiniTwitch.Common Changelog
+
+## Upcoming version
+
+- Minor: Improved handling of WebSocket reads

--- a/MiniTwitch.Common/Internal/Models/ByteBucket.cs
+++ b/MiniTwitch.Common/Internal/Models/ByteBucket.cs
@@ -23,9 +23,15 @@ internal sealed class ByteBucket
     /// <returns><see langword="true"/> if the bucket should be drained</returns>
     public async ValueTask<bool> FillFrom(ClientWebSocket source, CancellationToken cToken)
     {
+        ValueTask<ValueWebSocketReceiveResult> valueTask = source.ReceiveAsync(_temp, cToken);
+        if (valueTask.IsCanceled || cToken.IsCancellationRequested)
+        {
+            return false;
+        }
+
         // Receive bytes into _temp
         // This overwrites previous data
-        ValueWebSocketReceiveResult result = await source.ReceiveAsync(_temp, cToken);
+        ValueWebSocketReceiveResult result = await valueTask.ConfigureAwait(false);
         // Copy the received bytes into the bucket
         _temp[..result.Count].CopyTo(_bucket[_reached..(result.Count + _reached)]);
         _reached += result.Count;


### PR DESCRIPTION
This PR aims to tackle some potential WebSocket receiving issues, as Microsoft pointed out:
> Exactly one send and one receive is supported on each [ClientWebSocket](https://learn.microsoft.com/en-us/dotnet/api/system.net.websockets.clientwebsocket?view=net-8.0) object in parallel. Issuing multiple receives at the same time is not supported and will result in an undefined behavior.

This PR adds a semaphore to the receive operation to ensure that it's only issued once.

A CHANGELOG.md file for the project has also been added