### PR TITLE
Add usernotice tag for gifts 'msg-param-community-gift-id'

### DIFF
--- a/MiniTwitch.Irc.Test/SpanSumTests.cs
+++ b/MiniTwitch.Irc.Test/SpanSumTests.cs
@@ -59,6 +59,7 @@ public class SpanSumTests
         { (int)Tags.MsgParamSubPlanName, "msg-param-sub-plan-name" },
         { (int)Tags.MsgParamStreakMonths, "msg-param-streak-months" },
         { (int)Tags.MsgParamMassGiftCount, "msg-param-mass-gift-count" },
+        { (int)Tags.MsgParamCommunityGiftId, "msg-param-community-gift-id" },
         { (int)Tags.MsgParamCumulativeMonths, "msg-param-cumulative-months" },
         { (int)Tags.MsgParamRecipientUserName, "msg-param-recipient-user-name" },
         { (int)Tags.MsgParamShouldShareStreak, "msg-param-should-share-streak" },

--- a/MiniTwitch.Irc/Interfaces/IGiftSubNotice.cs
+++ b/MiniTwitch.Irc/Interfaces/IGiftSubNotice.cs
@@ -38,4 +38,8 @@ public interface IGiftSubNotice : IUsernotice
     /// The tier of the gift subscription
     /// </summary>
     SubPlan SubPlan { get; }
+    /// <summary>
+    /// Id of the parent <see cref="IGiftSubNoticeIntro"/> gift message
+    /// </summary>
+    ulong CommunityGiftId { get; }
 }

--- a/MiniTwitch.Irc/Interfaces/IGiftSubNoticeIntro.cs
+++ b/MiniTwitch.Irc/Interfaces/IGiftSubNoticeIntro.cs
@@ -24,4 +24,8 @@ public interface IGiftSubNoticeIntro : IUsernotice
     /// The tier of the gift subscriptions
     /// </summary>
     SubPlan SubPlan { get; }
+    /// <summary>
+    /// Id of the gift message to link it with <see cref="IGiftSubNotice"/> messages
+    /// </summary>
+    ulong CommunityGiftId { get; }
 }

--- a/MiniTwitch.Irc/Internal/Enums/Tags.cs
+++ b/MiniTwitch.Irc/Internal/Enums/Tags.cs
@@ -51,6 +51,7 @@ internal enum Tags
     MsgParamSubPlanName = 240890,
     MsgParamStreakMonths = 251354,
     MsgParamMassGiftCount = 267159,
+    MsgParamCommunityGiftId = 290376,
     MsgParamCumulativeMonths = 298987,
     MsgParamRecipientUserName = 312067,
     MsgParamShouldShareStreak = 313048,

--- a/MiniTwitch.Irc/Internal/Parsing/TagHelper.cs
+++ b/MiniTwitch.Irc/Internal/Parsing/TagHelper.cs
@@ -54,6 +54,11 @@ internal static class TagHelper
         return span[0] == dash ? -1 * ParseLong(span[1..]) : ParseLong(span);
     }
 
+    public static ulong GetULong(ReadOnlySpan<byte> span)
+    {
+        return ParseULong(span);
+    }
+
     public static TEnum GetEnum<TEnum>(ReadOnlySpan<byte> span, bool useTry = true)
     where TEnum : struct
     {
@@ -114,6 +119,20 @@ internal static class TagHelper
         {
             result *= 10L;
             result += b - numBase;
+        }
+
+        return result;
+    }
+
+    private static ulong ParseULong(ReadOnlySpan<byte> span)
+    {
+        const byte numBase = (byte)'0';
+
+        ulong result = 0;
+        foreach (byte b in span)
+        {
+            result *= 10L;
+            result += (ulong)b - numBase;
         }
 
         return result;

--- a/MiniTwitch.Irc/Models/Usernotice.cs
+++ b/MiniTwitch.Irc/Models/Usernotice.cs
@@ -67,6 +67,8 @@ public readonly struct Usernotice : IGiftSubNoticeIntro, IAnnouncementNotice, IP
     public int ViewerCount { get; init; }
     /// <inheritdoc/>
     public bool ShouldShareStreak { get; init; }
+    /// <inheritdoc/>
+    public ulong CommunityGiftId { get; init; }
 
     /// <inheritdoc/>
     public long TmiSentTs { get; init; } = default;
@@ -116,6 +118,7 @@ public readonly struct Usernotice : IGiftSubNoticeIntro, IAnnouncementNotice, IP
         int totalGiftCount = 0;
         int viewerCount = 0;
         bool shouldShareStreak = false;
+        ulong communityGiftId = 0;
 
         string charityName = string.Empty;
         int donationAmount = 0;
@@ -276,6 +279,11 @@ public readonly struct Usernotice : IGiftSubNoticeIntro, IAnnouncementNotice, IP
                     giftCount = TagHelper.GetInt(tagValue);
                     break;
 
+                //msg-param-community-gift-id
+                case (int)Tags.MsgParamCommunityGiftId:
+                    communityGiftId = TagHelper.GetULong(tagValue);
+                    break;
+
                 //msg-param-cumulative-months
                 case (int)Tags.MsgParamCumulativeMonths:
                     cumulativeMonths = TagHelper.GetInt(tagValue);
@@ -373,6 +381,7 @@ public readonly struct Usernotice : IGiftSubNoticeIntro, IAnnouncementNotice, IP
         this.CharityName = charityName;
         this.DonationAmount = actualDonationAmount;
         this.DonationCurrency = donationCurrency;
+        this.CommunityGiftId = communityGiftId;
     }
 
     /// <summary>


### PR DESCRIPTION
This is a new tag that helps link individual subgift messages to their parent subgift announcement

I hope this helps to visualize it:
![image](https://github.com/Foretack/MiniTwitch/assets/69414142/ed4f8dc5-6d09-4661-8637-a3918f2c4817)
