### PR TITLE
Expose `WebSocketClient.IsConnected` to the user

### DIFF
--- a/MiniTwitch.Irc/IrcClient.cs
+++ b/MiniTwitch.Irc/IrcClient.cs
@@ -30,6 +30,10 @@ public sealed class IrcClient : IAsyncDisposable
     /// <para>Can be toggled with <see cref="DefaultMiniTwitchLogger{T}.Enabled"/></para>
     /// </summary>
     public DefaultMiniTwitchLogger<IrcChannel> DefaultLogger { get; } = new();
+    /// <summary>
+    /// Whether the client is currently connected
+    /// </summary>
+    public bool IsConnected => _ws.IsConnected;
 
     internal ClientOptions Options { get; init; }
     #endregion

--- a/MiniTwitch.Irc/IrcMembershipClient.cs
+++ b/MiniTwitch.Irc/IrcMembershipClient.cs
@@ -24,6 +24,10 @@ public sealed class IrcMembershipClient : IAsyncDisposable
     /// The action to invoke when an exception is caught within an event
     /// </summary>
     public Action<Exception> ExceptionHandler { get; set; } = default!;
+    /// <summary>
+    /// Whether the client is currently connected
+    /// </summary>
+    public bool IsConnected => _ws.IsConnected;
     #endregion
 
     #region Events

--- a/MiniTwitch.PubSub/PubSubClient.cs
+++ b/MiniTwitch.PubSub/PubSubClient.cs
@@ -9,8 +9,8 @@ using MiniTwitch.PubSub.Internal;
 using MiniTwitch.PubSub.Internal.Enums;
 using MiniTwitch.PubSub.Internal.Models;
 using MiniTwitch.PubSub.Internal.Parsing;
-using MiniTwitch.PubSub.Payloads;
 using MiniTwitch.PubSub.Models;
+using MiniTwitch.PubSub.Payloads;
 
 namespace MiniTwitch.PubSub;
 
@@ -33,6 +33,10 @@ public sealed class PubSubClient : IAsyncDisposable
     /// <para>Can be toggled with <see cref="DefaultMiniTwitchLogger{T}.Enabled"/></para>
     /// </summary>
     public DefaultMiniTwitchLogger<PubSubClient> DefaultLogger { get; } = new();
+    /// <summary>
+    /// Whether the client is currently connected
+    /// </summary>
+    public bool IsConnected => _ws.IsConnected;
     #endregion
 
     #region Events


### PR DESCRIPTION
Currently, there is no way for the user to know the connection state of a ws-based client. This PR exposes the property `IsConnected` from the internal `WebSocketClient` fields to the user. While this doesn't expose the entirety of a websocket client's state, it ought to be enough to give an indication for figuring out if an instance is connected or not.

Applies to `IrcClient`, `IrcMembershipClient` and `PubSubClient`.
