### PR TITLE
Fix ChatSettings deserialization issues

### DIFF
--- a/MiniTwitch.Helix/Responses/ChatSettings.cs
+++ b/MiniTwitch.Helix/Responses/ChatSettings.cs
@@ -7,13 +7,13 @@ public class ChatSettings : BaseResponse<ChatSettings.Settings>
     public record Settings(
         long BroadcasterId,
         bool SlowMode,
-        int SlowModeWaitTime,
+        int? SlowModeWaitTime,
         bool FollowerMode,
-        int FollowerModeDuration,
+        int? FollowerModeDuration,
         bool SubscriberMode,
         bool EmoteMode,
         bool UniqueChatMode,
         bool NonModeratorChatDelay,
-        int NonModeratorChatDelayDuration
+        int? NonModeratorChatDelayDuration
     );
 }


### PR DESCRIPTION
Deserializing into this type from an actual helix request always threw exceptions when slow mode, follower mode or non mod chat delay were on. This is its fix