### PR TITLE
Fix DateTime deserialization in `GetBannedUsers()`

### DIFF
--- a/MiniTwitch.Helix/Internal/Json/Converters.cs
+++ b/MiniTwitch.Helix/Internal/Json/Converters.cs
@@ -169,3 +169,42 @@ public class ConduitTransportConverter : JsonConverter<ConduitTransport>
         return null;
     }
 }
+
+/// <summary>
+/// Reads DateTime? from string. Writes DateTime as string. <br/>
+/// NOTE: This does not do any validation.
+/// </summary>
+internal class OptionalDateTimeConverter : JsonConverter<DateTime?>
+{
+    public override DateTime? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TryGetDateTime(out var dateTime))
+        {
+            return dateTime;
+        }
+
+        if (reader.TokenType == JsonTokenType.Null || reader.ValueSpan.Length == 0)
+        {
+            return null;
+        }
+
+        var str = reader.GetString();
+        if (string.IsNullOrEmpty(str))
+        {
+            return null;
+        }
+
+        throw new JsonException($"Cannot convert value {str} to DateTime?");
+    }
+
+    public override void Write(Utf8JsonWriter writer, DateTime? value, JsonSerializerOptions options)
+    {
+        if (value is null)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        writer.WriteStringValue($"{value:O}");
+    }
+}

--- a/MiniTwitch.Helix/Responses/BannedUsers.cs
+++ b/MiniTwitch.Helix/Responses/BannedUsers.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using MiniTwitch.Helix.Internal.Json;
 using MiniTwitch.Helix.Models;
 
 namespace MiniTwitch.Helix.Responses;
@@ -6,13 +7,13 @@ namespace MiniTwitch.Helix.Responses;
 public class BannedUsers : PaginableResponse<BannedUsers.User>
 {
     public record User(
-       long UserId,
+        long UserId,
         [property: JsonPropertyName("user_login")] string Username,
         [property: JsonPropertyName("user_name")] string UserDisplayName,
-         DateTime? ExpiresAt,
-         DateTime CreatedAt,
-         string Reason,
-         long ModeratorId,
+        [property: JsonConverter(typeof(OptionalDateTimeConverter))] DateTime? ExpiresAt,
+        DateTime CreatedAt,
+        string Reason,
+        long ModeratorId,
         [property: JsonPropertyName("moderator_login")] string ModeratorName,
         [property: JsonPropertyName("moderator_name")] string ModeratorDisplayName
     );


### PR DESCRIPTION
Permanently banned users appear with `"expires_at": ""`, which was causing the deserialization into BannedUsers to fail. This PR fixes that