### PR TITLE
Add IAsyncEnumerable pagination method

### DIFF
--- a/MiniTwitch.Helix/Models/HelixResult.cs
+++ b/MiniTwitch.Helix/Models/HelixResult.cs
@@ -69,7 +69,8 @@ public readonly struct HelixResult<TResult> : IHelixResult
     /// Whether the request can fetch the next page of content
     /// </summary>
     public bool CanPaginate =>
-        this.Value is IPaginable p
+        this.Success
+        && this.Value is IPaginable p
         && p.Pagination.Cursor is { Length: > 0 }
         && this.HelixTask is not null;
 

--- a/MiniTwitch.Helix/Models/HelixResult.cs
+++ b/MiniTwitch.Helix/Models/HelixResult.cs
@@ -41,7 +41,7 @@ public readonly struct HelixResult<TResult> : IHelixResult
 {
     /// <summary>
     /// The response's content as <typeparamref name="TResult"/>
-    /// <para>This value should only be used if <see cref="Success"/> is <see langword="true"/></para>
+    /// <para>This value should only be accessed if <see cref="Success"/> is <see langword="true"/></para>
     /// </summary>
     public TResult Value { get; init; }
     /// <summary>
@@ -96,8 +96,9 @@ public readonly struct HelixResult<TResult> : IHelixResult
 
     /// <summary>
     /// Fetches the next pages of content and returns them via IAsyncEnumerable
+    /// <para>Does nothing if <see cref="CanPaginate"/> is <see langword="false"/></para>
     /// </summary>
-    public async IAsyncEnumerable<HelixResult<TResult>> PaginateEnumerable(
+    public async IAsyncEnumerable<HelixResult<TResult>> EnumeratePages(
         [EnumeratorCancellation] CancellationToken cancellationToken = default
     )
     {
@@ -114,10 +115,11 @@ public readonly struct HelixResult<TResult> : IHelixResult
 
     /// <summary>
     /// Fetches the next pages of content and returns them via IAsyncEnumerable
+    /// <para>Does nothing if <see cref="CanPaginate"/> is <see langword="false"/></para>
     /// </summary>
     /// <param name="limit">The maximum amount of pages to fetch before stopping</param>
     /// <param name="cancellationToken"></param>
-    public async IAsyncEnumerable<HelixResult<TResult>> PaginateEnumerable(
+    public async IAsyncEnumerable<HelixResult<TResult>> EnumeratePages(
         int limit,
         [EnumeratorCancellation] CancellationToken cancellationToken = default
     )

--- a/MiniTwitch.Helix/README.md
+++ b/MiniTwitch.Helix/README.md
@@ -21,10 +21,7 @@ MiniTwitch.Helix conveniently wraps the Twitch Helix API and exposes them throug
 
 ## Getting Started
 
-This example demonstrates the usage of `HelixWrapper` and `HelixResult<T>.Paginate()`
-
-> [!IMPORTANT]  
-> You may notice that some requests have missing parameters. This is because the user ID is supplied by the library to requests that require the user ID of the provided token
+This example demonstrates the usage of `HelixWrapper` and  pagination through `HelixResult<T>`
 
 ```csharp
 using MiniTwitch.Helix;
@@ -39,49 +36,36 @@ public class Program
 
     static async Task Main()
     {
-        Helix = new HelixWrapper("Access token", 987654321);
+        Helix = new HelixWrapper("wjm4xzd5fxp4ilaykzmmwc3dett9vm", 783267696);
 
-        var chatters = await GetAllChatters(12345678);
+        var emotes = await GetAllMyEmotes();
     }
 
-    private static async Task<List<string>> GetAllChatters(long broadcasterId)
+    private static async Task<List<string>> GetAllMyEmotes()
     {
-        List<string> usernames = [];
-        HelixResult<Chatters> chatters = await Helix.GetChatters(broadcasterId, first: 1000);
-
-        if (!chatters.Success)
+        HelixResult<UserEmotes> emotesResult = await Helix.GetUserEmotes();
+        if (!emotesResult.Success)
         {
             return [];
         }
 
-        foreach (var chatter in chatters.Value.Data)
+        List<string> emoteList = [];
+        foreach (var emote in emotesResult.Value.Data)
         {
-            usernames.Add(chatter.Username);
+            emoteList.Add(emote.Name);
         }
 
-        // No more users - return what we got
-        if (!chatters.CanPaginate)
+        // Fetch the next pages of content.
+        // The code inside will not run if there are no more pages.
+        await foreach (var nextEmotesResult in emotesResult.PaginateEnumerable())
         {
-            return usernames;
-        }
-
-        // Continue paginating if the result is a success
-        while (await chatters.Paginate() is { Success: true } next)
-        {
-            foreach (var chatter in next.Value.Data)
+            foreach (var emote in nextEmotesResult.Value.Data)
             {
-                usernames.Add(chatter.Username);
+                emoteList.Add(emote.Name);
             }
-
-            // Return when pagination is no longer possible
-            if (!next.CanPaginate)
-                return usernames;
-
-            // Assign the new page to the old one so we move forward
-            chatters = next;
         }
 
-        return usernames;
+        return emoteList;
     }
 }
 ```

--- a/MiniTwitch.Helix/README.md
+++ b/MiniTwitch.Helix/README.md
@@ -57,7 +57,7 @@ public class Program
 
         // Fetch the next pages of content.
         // The code inside will not run if there are no more pages.
-        await foreach (var nextEmotesResult in emotesResult.PaginateEnumerable())
+        await foreach (var nextEmotesResult in emotesResult.EnumeratePages())
         {
             foreach (var emote in nextEmotesResult.Value.Data)
             {

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ public class Program
 
         // Fetch the next pages of content.
         // The code inside will not run if there are no more pages.
-        await foreach (var nextEmotesResult in emotesResult.PaginateEnumerable())
+        await foreach (var nextEmotesResult in emotesResult.EnumeratePages())
         {
             foreach (var emote in nextEmotesResult.Value.Data)
             {


### PR DESCRIPTION
This allows `await foreach` to be used to fetch the next pages of content, which is a much friendlier approach than whatever was in the readme example