### PR TITLE
Add MessageAuthor.IsBot

### DIFF
--- a/MiniTwitch.Irc.Test/PrivmsgTests.cs
+++ b/MiniTwitch.Irc.Test/PrivmsgTests.cs
@@ -370,4 +370,23 @@ public class PrivmsgTests
         Assert.False(privmsg.Author.IsVip);
         Assert.True(privmsg.Author.IsLeadMod);
     }
+
+    [Fact]
+    public void IsBot()
+    {
+        var privmsg = Privmsg.Construct("@badge-info=;badges=bot-badge/1;client-nonce=eed215dbfe1f62033bd287c5f832ff64;color=#1E90FF;display-name=AlcaBot;emotes=;first-msg=0;flags=;id=e85c9083-b998-44fc-a392-a9a8ea64d3aa;mod=1;returning-chatter=0;room-id=7676884;subscriber=0;tmi-sent-ts=1766900598952;turbo=0;user-id=70310077;user-type=mod :alcabot!alcabot@alcabot.tmi.twitch.tv PRIVMSG #alca :Test");
+        // Author
+        Assert.Equal(70310077, privmsg.Author.Id);
+        Assert.Equal(UserType.Mod, privmsg.Author.Type);
+        Assert.False(privmsg.Author.IsSubscriber);
+        Assert.Equal("AlcaBot", privmsg.Author.DisplayName);
+        Assert.Equal("alcabot", privmsg.Author.Name);
+        Assert.True(privmsg.Author.IsMod);
+        Assert.False(privmsg.Author.IsTurbo);
+        Assert.Equal("1E90FF".ToLower(), privmsg.Author.ChatColor.Name);
+        Assert.Empty(privmsg.Author.BadgeInfo);
+        Assert.Equal("bot-badge/1", privmsg.Author.Badges);
+        Assert.False(privmsg.Author.IsVip);
+        Assert.True(privmsg.Author.IsBot);
+    }
 }

--- a/MiniTwitch.Irc/Interfaces/IUserstateSelf.cs
+++ b/MiniTwitch.Irc/Interfaces/IUserstateSelf.cs
@@ -49,4 +49,8 @@ public interface IUserstateSelf
     /// <para>Note: Might not be working as Twitch is not sending this info for USERSTATEs yet</para>
     /// </summary>
     bool IsLeadMod { get; }
+    /// <summary>
+    /// Whether you are a bot
+    /// </summary>
+    bool IsBot { get; }
 }

--- a/MiniTwitch.Irc/Models/MessageAuthor.cs
+++ b/MiniTwitch.Irc/Models/MessageAuthor.cs
@@ -72,6 +72,10 @@ public readonly struct MessageAuthor : IBanTarget, IDeletedMessageAuthor, IWhisp
     /// Gets a value indicating whether the user is a lead moderator
     /// </summary>
     public bool IsLeadMod => this.Badges.AsSpan().Contains("lead_moderator/1", StringComparison.Ordinal);
+    /// <summary>
+    /// Gets a value indicating whether the user is a bot
+    /// </summary>
+    public bool IsBot => this.Badges.AsSpan().Contains("bot-badge/1", StringComparison.Ordinal);
 
 #pragma warning disable CS8765 // Nullability of type of parameter doesn't match overridden member (possibly because of nullability attributes).
     /// <inheritdoc/>


### PR DESCRIPTION
This pull request adds support for detecting whether a user is a bot in the IRC message model, interface, and test coverage. The change introduces a new `IsBot` property to indicate if a user has the bot badge.

**Bot detection support:**

* Added an `IsBot` property to the `IUserstateSelf` interface to expose bot status for users.
* Implemented the `IsBot` property in the `MessageAuthor` model, which checks for the `bot-badge/1` badge in the user's badges.
* Added a new test case in `PrivmsgTests.cs` to verify correct behavior of the `IsBot` property for users with the bot badge.

Reference: https://www.streamdatabase.com/twitch/global-badges/bot-badge/1